### PR TITLE
Fix opengl vertex array integer attribute bug

### DIFF
--- a/Basement/source/Basement/Renderer/CameraController.cpp
+++ b/Basement/source/Basement/Renderer/CameraController.cpp
@@ -10,7 +10,7 @@ static const float DefaultZoomSpeed = 2.0f;
 static const float DefaultRotationSpeed3D = 0.3f;
 
 namespace Basement {
-	
+
 	//--------------------------------------------------------------
 	//---Perspective Camera Controller------------------------------
 
@@ -48,11 +48,11 @@ namespace Basement {
 		{
 			m_Position += m_Camera.GetRight() * (m_MoveSpeed * dt);
 		}
-		if (Basement::Input::IsKeyPressed(BM_KEY_R))
+		if (Basement::Input::IsKeyPressed(BM_KEY_E))
 		{
 			m_Position += m_Camera.GetUp() * (m_MoveSpeed * dt);
 		}
-		else if (Basement::Input::IsKeyPressed(BM_KEY_F))
+		else if (Basement::Input::IsKeyPressed(BM_KEY_Q))
 		{
 			m_Position -= m_Camera.GetUp() * (m_MoveSpeed * dt);
 		}
@@ -73,7 +73,7 @@ namespace Basement {
 		// TODO: zoom in/out by changine the distance between focal point and camera position
 		if (m_Fov >= 1.0f && m_Fov <= 90.0f)
 			m_Fov -= (event.GetOffsetY() * m_ZoomSpeed);
-		
+
 		// Fov = [1, 90]
 		m_Fov = (m_Fov >= 1.0f) ? m_Fov : 1.0f;
 		m_Fov = (m_Fov <= 90.0) ? m_Fov : 90.0f;
@@ -84,7 +84,7 @@ namespace Basement {
 		m_ZoomLevel -= event.GetOffsetY() * 0.2f;
 		m_ZoomLevel = std::max(m_ZoomLevel, 0.25f);
 		m_MoveSpeed = DefaultMoveSpeed * m_ZoomLevel;
-		m_RotationSpeed= DefaultRotationSpeed3D * m_ZoomLevel;
+		m_RotationSpeed = DefaultRotationSpeed3D * m_ZoomLevel;
 
 		return false;
 	}
@@ -102,7 +102,7 @@ namespace Basement {
 			m_Pitch -= (offset.y * m_RotationSpeed);
 		}
 		m_Camera.SetRotation(m_Yaw, m_Pitch);
-		
+
 		return false;
 	}
 

--- a/Basement/source/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Basement/source/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -10,17 +10,17 @@ namespace Basement {
 	{
 		switch (type)
 		{
-			case EShaderDataType::Int:      return GL_INT;
-			case EShaderDataType::Int2:     return GL_INT;
-			case EShaderDataType::Int3:     return GL_INT;
-			case EShaderDataType::Int4:     return GL_INT;
-			case EShaderDataType::Float:    return GL_FLOAT;
-			case EShaderDataType::Float2:   return GL_FLOAT;
-			case EShaderDataType::Float3:   return GL_FLOAT;
-			case EShaderDataType::Float4:   return GL_FLOAT;
-			case EShaderDataType::Mat3:     return GL_FLOAT;
-			case EShaderDataType::Mat4:     return GL_FLOAT;
-			case EShaderDataType::Bool:     return GL_BOOL;
+		case EShaderDataType::Int:      return GL_INT;
+		case EShaderDataType::Int2:     return GL_INT;
+		case EShaderDataType::Int3:     return GL_INT;
+		case EShaderDataType::Int4:     return GL_INT;
+		case EShaderDataType::Float:    return GL_FLOAT;
+		case EShaderDataType::Float2:   return GL_FLOAT;
+		case EShaderDataType::Float3:   return GL_FLOAT;
+		case EShaderDataType::Float4:   return GL_FLOAT;
+		case EShaderDataType::Mat3:     return GL_FLOAT;
+		case EShaderDataType::Mat4:     return GL_FLOAT;
+		case EShaderDataType::Bool:     return GL_BOOL;
 		}
 
 		BM_CORE_ASSERT(false, "Unknown ShaderDataType!");
@@ -52,7 +52,7 @@ namespace Basement {
 	void OpenGLVertexArray::AddVertexBuffer(const SharedPtr<VertexBuffer>& vertexBuffer)
 	{
 		BM_CORE_ASSERT(vertexBuffer->GetLayout().GetElements().size(), "Vertex Buffer has no layout!");
-		
+
 		glBindVertexArray(m_VertexArrayID);
 		vertexBuffer->Bind();
 
@@ -62,15 +62,32 @@ namespace Basement {
 		{
 			// Set vertex attributes
 			glEnableVertexAttribArray(index + m_VertexArrayIndexOffset);
-			glVertexAttribPointer
-			(
-				index + m_VertexArrayIndexOffset,
-				element.GetComponentCount(),
-				ShaderDataTypeToOpenGLBaseType(element.Type),
-				element.bIsNormalized ? GL_TRUE : GL_FALSE,
-				vertexBuffer->GetLayout().GetStride(),
-				(const void*)(intptr_t)element.Offset
-			);
+			bool isIntegerType = element.Type == EShaderDataType::Int || element.Type == EShaderDataType::Int2 ||
+				element.Type == EShaderDataType::Int3 || element.Type == EShaderDataType::Int4;
+
+			if (isIntegerType)
+			{
+				glVertexAttribIPointer
+				(
+					index + m_VertexArrayIndexOffset,
+					element.GetComponentCount(),
+					ShaderDataTypeToOpenGLBaseType(element.Type),
+					vertexBuffer->GetLayout().GetStride(),
+					(const void*)(intptr_t)element.Offset
+				);
+			}
+			else
+			{
+				glVertexAttribPointer
+				(
+					index + m_VertexArrayIndexOffset,
+					element.GetComponentCount(),
+					ShaderDataTypeToOpenGLBaseType(element.Type),
+					element.bIsNormalized ? GL_TRUE : GL_FALSE,
+					vertexBuffer->GetLayout().GetStride(),
+					(const void*)(intptr_t)element.Offset
+				);
+			}
 
 			++index;
 		}


### PR DESCRIPTION
This PR fixes the vertex array integer attribute bug on OpenGL problem. 

It is found based on the animation branch when sending boneID(int) to shader.